### PR TITLE
extend allowed characters to include _ and $

### DIFF
--- a/src/normalizeName.js
+++ b/src/normalizeName.js
@@ -2,8 +2,8 @@
 
 import camelcase from 'camelcase';
 
-const ValidNameRegex = /^[a-z][a-z0-9]+$/;
-const AlphabeticalCharacterRegex = /[a-z]/i;
+const ValidNameRegex = /^[a-zA-Z_$][0-9a-zA-Z_$]+$/;
+const AlphabeticalCharacterRegex = /[a-zA-Z_$]/i;
 
 export default (name: string): string => {
   if (ValidNameRegex.test(name)) {


### PR DESCRIPTION
* JS supports many more characters than the ones defined in this plugin. (A detailed discussion can be found [here](https://stackoverflow.com/questions/1661197/what-characters-are-valid-for-javascript-variable-names))

 > An identifier must start with $, _, or any character in the Unicode categories “Uppercase letter (Lu)”, “Lowercase letter (Ll)”, “Titlecase letter (Lt)”, “Modifier letter (Lm)”, “Other letter (Lo)”, or “Letter number (Nl)”.

* "You can use Unicode characters in identifiers, but don't do it. Encodings get screwed up all the time. Keep your public identifiers in the 32-126 ASCII range where it's safe." - [Anthony Mills](https://stackoverflow.com/a/1661249/599991)

* in some cases, it might be impossible to avoid naming files with `_`. (e.g. [next.js forces the creation of a file named `_document.js`](https://github.com/zeit/next.js#custom-document)
