### PR TITLE
fix: register variable declaration in scope

### DIFF
--- a/src/deriveName.js
+++ b/src/deriveName.js
@@ -9,7 +9,7 @@ export default (state: Object, scope: Object): string => {
 
   let name = filename;
 
-  name = path.basename(name, '.js');
+  name = path.parse(name).name;
 
   if (name === 'index') {
     name = path.basename(path.dirname(filename));

--- a/src/index.js
+++ b/src/index.js
@@ -10,12 +10,14 @@ export default ({
   const replace = (path, name: string, replacement) => {
     const id = t.identifier(name);
 
-    path.replaceWithMultiple([
+    const [varDeclPath] = path.replaceWithMultiple([
       t.variableDeclaration('const', [
         t.variableDeclarator(id, replacement)
       ]),
       t.exportDefaultDeclaration(id)
     ]);
+
+    path.scope.registerDeclaration(varDeclPath);
   };
 
   return {


### PR DESCRIPTION
This prevents the babel typescript plugin from getting confused at the undeclared variable and emitting a noisy warning.

Fixes #15 

@gajus I hit this warning when converting slonik to TypeScript - it doesn't break anything but it spams the output a lot when running tests. The fix is based on this PR which addresses a similar issue: https://github.com/babel/babel/pull/10302