### PR TITLE
Transform invalid file names instead of throwing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,15 @@
 {
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": 5
+        }
+      }
+    ]
+  ],
   "plugins": [
-    "transform-es2015-modules-commonjs",
-    "transform-es2015-parameters",
-    "transform-es2015-block-scoping",
-    "transform-es2015-destructuring",
     "transform-flow-strip-types"
   ]
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,14 @@
 [ignore]
+<PROJECT_ROOT>/node_modules/gensync/index.js.flow
+<PROJECT_ROOT>/node_modules/resolve/test/resolver/malformed_package_json/package.json
+<PROJECT_ROOT>/node_modules/eslint-plugin-jsx-a11y/__tests__/__util__/ruleOptionsMapperFactory.js
+<PROJECT_ROOT>/node_modules/eslint-plugin-jsx-a11y/__mocks__/genInteractives.js
+<PROJECT_ROOT>/node_modules/eslint-plugin-jsx-a11y/__mocks__/JSXAttributeMock.js
+<PROJECT_ROOT>/node_modules/eslint-plugin-jsx-a11y/__mocks__/JSXElementMock.js
+<PROJECT_ROOT>/node_modules/eslint-plugin-flowtype/dist/bin/checkDocs.js
+<PROJECT_ROOT>/node_modules/dataloader/index.js.flow
+<PROJECT_ROOT>/node_modules/@babel/highlight/node_modules/chalk/index.js.flow
+<PROJECT_ROOT>/node_modules/@babel/helper-define-polyfill-provider/src/node/dependencies.js
 <PROJECT_ROOT>/node_modules/config-chain/test/broken.json
 <PROJECT_ROOT>/node_modules/conventional-changelog-core/test/fixtures/_malformation.json
 <PROJECT_ROOT>/node_modules/npmconf/test/fixtures/package.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 node_js:
   - node
-  - 7
-  - 6
-  - 5
 notifications:
   email: false
 sudo: false

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
     "name": "Gajus Kuizinas"
   },
   "ava": {
-    "babel": "inherit",
     "require": [
-      "babel-register"
+      "@babel/register"
     ]
   },
   "dependencies": {
@@ -14,18 +13,16 @@
   },
   "description": "Babel plugin that transforms default exports to named exports.",
   "devDependencies": {
-    "ava": "^0.17.0",
-    "babel-cli": "^6.18.0",
-    "babel-core": "^6.18.2",
-    "babel-plugin-transform-es2015-block-scoping": "^6.18.0",
-    "babel-plugin-transform-es2015-destructuring": "^6.19.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
-    "babel-plugin-transform-es2015-parameters": "^6.18.0",
-    "babel-plugin-transform-flow-strip-types": "^6.18.0",
-    "eslint": "^3.11.1",
-    "eslint-config-canonical": "^5.8.0",
+    "ava": "^4.2.0",
+    "@babel/cli": "^7.17.6",
+    "@babel/core": "^7.17.9",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/register": "^7.17.7",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "eslint": "^8.13.0",
+    "eslint-config-canonical": "^34.2.1",
     "flow-bin": "^0.36.0",
-    "husky": "^0.11.9"
+    "husky": "^7.0.4"
   },
   "keywords": [
     "babel-plugin"

--- a/src/index.js
+++ b/src/index.js
@@ -3,21 +3,24 @@
 import deriveName from './deriveName';
 
 export default ({
-  types: t
+  // eslint-disable-next-line id-length
+  types: t,
 }: {
   types: Object
 }) => {
   const replace = (path, name: string, replacement) => {
     const id = t.identifier(name);
 
-    const [varDeclPath] = path.replaceWithMultiple([
+    const [
+      variableDeclPath,
+    ] = path.replaceWithMultiple([
       t.variableDeclaration('const', [
-        t.variableDeclarator(id, replacement)
+        t.variableDeclarator(id, replacement),
       ]),
-      t.exportDefaultDeclaration(id)
+      t.exportDefaultDeclaration(id),
     ]);
 
-    path.scope.registerDeclaration(varDeclPath);
+    path.scope.registerDeclaration(variableDeclPath);
   };
 
   return {
@@ -69,7 +72,7 @@ export default ({
           // eslint-disable-next-line no-useless-return
           return;
         }
-      }
-    }
+      },
+    },
   };
 };

--- a/src/normalizeName.js
+++ b/src/normalizeName.js
@@ -2,28 +2,28 @@
 
 import camelcase from 'camelcase';
 
-const ValidNameRegex = /^[a-zA-Z_$][0-9a-zA-Z_$]+$/;
-const AlphabeticalCharacterRegex = /[a-zA-Z_$]/i;
+const ValidNameRegex = /^[$A-Z_a-z][\w$]+$/u;
+const AlphabeticalCharacterRegex = /[$_a-z]/iu;
 
 export default (name: string): string => {
   if (ValidNameRegex.test(name)) {
     return name;
   }
 
-  let firstCharacter = name.slice(0, 1);
-
-  if (!AlphabeticalCharacterRegex.test(firstCharacter)) {
-    firstCharacter = '_';
-    name = '_' + name;
-  }
+  const firstCharacter = name.slice(0, 1);
 
   const firstCharacterUpperCase = firstCharacter.toUpperCase() === firstCharacter;
 
   const camelCaseName = camelcase(name);
 
+  let safeName = camelCaseName;
   if (firstCharacterUpperCase) {
-    return camelCaseName.slice(0, 1).toUpperCase() + camelCaseName.slice(1);
+    safeName = camelCaseName.slice(0, 1).toUpperCase() + camelCaseName.slice(1);
   }
 
-  return camelCaseName;
+  if (!AlphabeticalCharacterRegex.test(firstCharacter)) {
+    safeName = '_' + safeName;
+  }
+
+  return safeName;
 };

--- a/src/normalizeName.js
+++ b/src/normalizeName.js
@@ -10,10 +10,11 @@ export default (name: string): string => {
     return name;
   }
 
-  const firstCharacter = name.slice(0, 1);
+  let firstCharacter = name.slice(0, 1);
 
   if (!AlphabeticalCharacterRegex.test(firstCharacter)) {
-    throw new Error('Invalid name.');
+    firstCharacter = '_';
+    name = '_' + name;
   }
 
   const firstCharacterUpperCase = firstCharacter.toUpperCase() === firstCharacter;

--- a/src/resolveConflictingName.js
+++ b/src/resolveConflictingName.js
@@ -8,7 +8,7 @@ export default (name: string, scope: Object) => {
     resolvedName = name + index++;
 
     if (index > 100) {
-      throw Error('Couldn\'t resolve clashing name "' + name + '".');
+      throw new Error('Couldn\'t resolve clashing name "' + name + '".');
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,13 @@ test('exporting an arrow function with a file name that matches an existing vari
   t.true(actual === expected);
 });
 
+test('exporting an arrow function with an invalid file name: derives a new name using an underscore', (t) => {
+  const actual = transform('const foo = true; export default () => {};', '1.js');
+  const expected = 'const foo = true; const _1 = () => {}; export default _1;';
+
+  t.true(actual === expected);
+});
+
 test('exporting an arrow function with a file name that matches an existing variable: derives a new name using an incremental index (multiple iterations)', (t) => {
   const actual = transform('const foo = true;\nconst foo0 = true; export default () => {};', 'foo.js');
   const expected = 'const foo = true; const foo0 = true; const foo1 = () => {}; export default foo1;';

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
-import test from 'ava';
 import {
-  transform as nativeTransform
-} from 'babel-core';
+  transform as nativeTransform,
+} from '@babel/core';
+import test from 'ava';
 import plugin from '../src';
 
 const transform = (code, filename = 'unset.js') => {
@@ -9,87 +9,94 @@ const transform = (code, filename = 'unset.js') => {
     babelrc: false,
     filename,
     plugins: [
-      plugin
-    ]
-  }).code.replace(/\n/g, ' ').replace(/\s+/g, ' ');
+      plugin,
+    ],
+  }).code.replace(/\n/gu, ' ').replace(/\s+/gu, ' ');
 };
 
 test('exporting an arrow function with a safe file name: uses the file name to create an export variable', (t) => {
   const actual = transform('export default () => {};', 'foo.js');
   const expected = 'const foo = () => {}; export default foo;';
 
-  t.true(actual === expected);
+  t.is(actual, expected);
 });
 
 test('exporting an arrow function with an unsafe file name: sanitizes the file name using camelCase', (t) => {
   const actual = transform('export default () => {};', 'foo bar.js');
   const expected = 'const fooBar = () => {}; export default fooBar;';
 
-  t.true(actual === expected);
+  t.is(actual, expected);
 });
 
 test('exporting an arrow function with a file name that matches an existing variable: derives a new name using an incremental index', (t) => {
   const actual = transform('const foo = true; export default () => {};', 'foo.js');
   const expected = 'const foo = true; const foo0 = () => {}; export default foo0;';
 
-  t.true(actual === expected);
+  t.is(actual, expected);
 });
 
 test('exporting an arrow function with an invalid file name: derives a new name using an underscore', (t) => {
-  const actual = transform('const foo = true; export default () => {};', '1.js');
-  const expected = 'const foo = true; const _1 = () => {}; export default _1;';
+  const actual = transform('export default () => {};', '1.js');
+  const expected = 'const _1 = () => {}; export default _1;';
 
-  t.true(actual === expected);
+  t.is(actual, expected);
+});
+
+test('exporting an arrow function with a conflicting invalid file name: derives a new name using an underscore and index', (t) => {
+  const actual = transform('const _1 = true; export default () => {};', '1.js');
+  const expected = 'const _1 = true; const _10 = () => {}; export default _10;';
+
+  t.is(actual, expected);
 });
 
 test('exporting an arrow function with a file name that matches an existing variable: derives a new name using an incremental index (multiple iterations)', (t) => {
   const actual = transform('const foo = true;\nconst foo0 = true; export default () => {};', 'foo.js');
   const expected = 'const foo = true; const foo0 = true; const foo1 = () => {}; export default foo1;';
 
-  t.true(actual === expected);
+  t.is(actual, expected);
 });
 
 test('exporting an arrow function with "index" file name: uses the directory name', (t) => {
   const actual = transform('export default () => {};', 'foo/index.js');
   const expected = 'const foo = () => {}; export default foo;';
 
-  t.true(actual === expected);
+  t.is(actual, expected);
 });
 
 test('exporting an async arrow function', (t) => {
   const actual = transform('export default async () => {};', 'foo/index.js');
   const expected = 'const foo = async () => {}; export default foo;';
 
-  t.true(actual === expected);
+  t.is(actual, expected);
 });
 
 test('exporting an anonymous async function', (t) => {
-  const actual = transform('export default async function () {};', 'foo.js');
+  const actual = transform('export default async function () {}', 'foo.js');
   const expected = 'const foo = async function () {}; export default foo;';
 
-  t.true(actual === expected);
+  t.is(actual, expected);
 });
 
 test('exporting an anonymous class: uses the file name to create an export variable', (t) => {
   const actual = transform('export default class {}', 'Foo.js');
   const expected = 'const Foo = class {}; export default Foo;';
 
-  t.true(actual === expected);
+  t.is(actual, expected);
 });
 
 const fixtures = [
-  '[]',
-  '\'a string\'',
-  '1',
-  'true',
-  'new String("foo")',
-  'null',
+  '[];',
+  '\'a string\';',
+  '1;',
+  'true;',
+  'new String("foo");',
+  'null;',
   'class Foo {}',
-  'function foo() {}'
+  'function foo() {}',
 ];
 
 for (const fixture of fixtures) {
   test('exporting ' + fixture + ' does not transform code', (t) => {
-    t.true(transform('export default ' + fixture + ';') === 'export default ' + fixture + ';');
+    t.is(transform('export default ' + fixture), 'export default ' + fixture);
   });
 }


### PR DESCRIPTION
Having invalid filenames throw seems unnecessary, we can simply add a safe character to the start of the name